### PR TITLE
feat(sltt-app): make only one instance of app

### DIFF
--- a/compressor/src/config.js
+++ b/compressor/src/config.js
@@ -23,29 +23,29 @@ const getFileExtension = () => os.platform() === 'win32' ? '.exe' : ''
 
 let platform = os.platform() === 'win32' ? 'win32' : 'macos'
 
-// const oldFfmpegPath = path.join(__dirname, `/extraResources/${platform}/ffmpeg-x64${getFileExtension()}`)
-// const oldFfprobePath = path.join(__dirname, `/extraResources/${platform}/ffprobe-x64${getFileExtension()}`)
+// const srcFfmpegPath = path.join(__dirname, `/extraResources/${platform}/ffmpeg-x64${getFileExtension()}`)
+// const srcFfprobePath = path.join(__dirname, `/extraResources/${platform}/ffprobe-x64${getFileExtension()}`)
 // NOTE: including ffmpeg-static as a dependency makes for a large install package
 // For now just make paths specific to windows installation
 // TODO make paths work for linux and macos
 
-const oldFfmpegPath = require('ffmpeg-static').replace(
+const srcFfmpegPath = require('ffmpeg-static').replace(
     'app.asar',
     'app.asar.unpacked'
 );
-const oldFfprobePath = require('ffprobe-static').path.replace(
+const srcFfprobePath = require('ffprobe-static').path.replace(
     'app.asar',
     'app.asar.unpacked'
 );
-// const oldFfmpegPath = path.join(process.resourcesPath, 'node_modules/ffmpeg-static/ffmpeg.exe')
-// const oldFfprobePath = path.join(process.resourcesPath, 'node_modules/ffprobe-static/bin/win32/x64/ffprobe.exe')
+// const srcFfmpegPath = path.join(process.resourcesPath, 'node_modules/ffmpeg-static/ffmpeg.exe')
+// const srcFfprobePath = path.join(process.resourcesPath, 'node_modules/ffprobe-static/bin/win32/x64/ffprobe.exe')
 
-console.log(`oldFfmpegPath: ${oldFfmpegPath}`)
-console.log(`oldFfprobePath: ${oldFfprobePath}`)
+console.log(`srcFfmpegPath: ${srcFfmpegPath}`)
+console.log(`srcFfprobePath: ${srcFfprobePath}`)
 
 const ffmpegPath = path.join(resourcesPath, `/ffmpeg-x64${getFileExtension()}`)
 const ffprobePath = path.join(resourcesPath, `/ffprobe-x64${getFileExtension()}`)
 
 const version = '1.1'
 
-module.exports = { resourcesPath, videosPath, oldFfmpegPath, oldFfprobePath, ffmpegPath, ffprobePath, version, platform }
+module.exports = { resourcesPath, videosPath, srcFfmpegPath, srcFfprobePath, ffmpegPath, ffprobePath, version, platform }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sltt-app",
-  "version": "204600.0.16",
+  "version": "204600.0.17",
   "description": "Installable SLTT app (Sign Language Translation Tool)",
   "main": "./out/main/index.js",
   "author": "sltt-bible.net",


### PR DESCRIPTION
What issue(s) is this trying to resolve?
* feat(sltt-app): make only one instance of app #2
* fix: copy ffmpeg to resource folder if missing

How does it all work?
* add ensureOneInstanceOfSlttAppAndCompressor() in main process to ensure single instance of app and compressor

What particularly has changed?
* rename resource paths in terms of `src` rather than `old` paths
* add better console logs for resource copying
* bump version to `204600.0.17`

Steps for testing
### Scenario 1 - Single instance of app
1. after installing, double click on the app icon
2. minimize the app and double click on the app icon again
3. check if the app is restored from the minimized state
### Scenario 2 - Copy ffmpeg to resource folder if missing
1. close the app
2. in terminal, run 
```bash
del %TEMP%\compression-server\resources\ffmpeg-x64.exe
cd %USERPROFILE%\AppData\Local\Programs\sltt-app
.\sltt-app.exe
```
3. check if the console log says: `Copying ffmpeg resource to %TEMP%\compression-server\resources\ffmpeg-x64.exe`

ticket: https://github.com/ubsicap/sltt/issues/2
commit-convention: https://www.conventionalcommits.org/en/v1.0.0/