### PR TITLE
feat(sltt-app): maximize the window on load

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,7 @@ import icon from '../../resources/icon.png?asset'
 function createWindow(): BrowserWindow {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
-    width: 900,
+    width: 1400,
     height: 670,
     show: false,
     autoHideMenuBar: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,9 @@ function createWindow(): BrowserWindow {
     }
   })
 
+  // Maximize the window
+  mainWindow.maximize()
+
   mainWindow.on('ready-to-show', () => {
     mainWindow.show()
   })


### PR DESCRIPTION
What issue(s) is this trying to resolve?
*  feat(sltt-app): set browser window to maximized size #8

How does it all work?
* added mainWindow.maximize() to index.ts
* changed starting width to 1400 to show both passages and video

Steps for testing
1. Launch the App
2. The window should be maximized
3. Click the window size button in the upper right corner, and expect to still see video and passages (if your screen size allows)
![image](https://github.com/ubsicap/sltt-app/assets/1125565/d2d32e88-b4ec-4218-a8c0-67578f2f84b7)

![image](https://github.com/ubsicap/sltt-app/assets/1125565/f8985259-78e6-4949-9d8b-9b462d3e8815)

ticket: https://github.com/ubsicap/sltt-app/issues/8
commit-convention: https://www.conventionalcommits.org/en/v1.0.0/
