### PR TITLE
feat(sltt-app): add contextbridge api for storing videos to local disk outside of browser

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -4,7 +4,15 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()]
+    plugins: [externalizeDepsPlugin()],
+    build: {
+      rollupOptions: {
+        input: {
+          index: resolve(__dirname, 'src/main/index.ts'), // Existing main process entry
+          storage: resolve(__dirname, 'storage/index.ts') // New entry point
+        },
+      }
+    }
   },
   preload: {
     plugins: [externalizeDepsPlugin()]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sltt-app",
-  "version": "205100.0.21",
+  "version": "205104.0.22-alpha1",
   "description": "Installable SLTT app (Sign Language Translation Tool)",
   "main": "./out/main/index.js",
   "author": "sltt-bible.net",
@@ -19,8 +19,8 @@
     "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
-    "find:version:source": "findstr /S /M /C:\"version:\\\"2.51.0\\\"\" %SLTT_CLIENT_DIR%/build/static/js/main.*.chunk.js",
-    "find:version:target": "findstr /S /M /C:\"version:\\\"2.51.0\\\"\" out\\client\\static\\js\\main.*.chunk.js",
+    "find:version:source": "findstr /S /M /C:\"version:\\\"2.51.4\\\"\" %SLTT_CLIENT_DIR%/build/static/js/main.*.chunk.js",
+    "find:version:target": "findstr /S /M /C:\"version:\\\"2.51.4\\\"\" out\\client\\static\\js\\main.*.chunk.js",
     "find:auth0_client_id:target": "findstr /S /M /C:\"REACT_APP_AUTH0_CLIENT_ID:\\\"eTewsjcscudtGHteG3u86YEDwHUTRd6Z\\\"\" out\\client\\static\\js\\main.*.chunk.js",
     "find:auth0_client_id:source": "findstr /S /M /C:\"REACT_APP_AUTH0_CLIENT_ID:\\\"eTewsjcscudtGHteG3u86YEDwHUTRd6Z\\\"\" %SLTT_CLIENT_DIR%/build/static/js/main.*.chunk.js",
     "rmdir:build:client": "if exist .\\out\\client rmdir /s /q .\\out\\client",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -112,5 +112,6 @@ function loadUrlOrFile(mainWindow: BrowserWindow, options: LoadFileOptions | und
     mainWindow.loadFile(join(__dirname, '../client/index.html'), options)
   }
 }
-// In this file you can include the rest of your app"s specific main process
+// In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
+require('./storage.js')

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -12,7 +12,7 @@ ipcMain.handle(VIDEO_CACHE_API_TRY_RETRIEVE_BLOB, async (_, args) => {
     return new Promise(function (resolve, reject) {
         // do stuff
         if (args === 'test') {
-            resolve('test worked!')
+            resolve(`${VIDEO_CACHE_API_TRY_RETRIEVE_BLOB} api test worked!`)
         } else if (Array.isArray(args)
             && args.length === 2
             && typeof args[0] === 'string' 
@@ -46,8 +46,9 @@ ipcMain.handle(VIDEO_CACHE_API_STORE_BLOB, async (_, args) => {
         // do stuff
         if (args === 'test') {
             mkdirSync(VIDEO_CACHE_PATH, { recursive: true })
-            writeFileSync(join(VIDEO_CACHE_PATH, 'mytest.txt'), 'test worked!')
-            resolve('test worked!')
+            const testPath = join(VIDEO_CACHE_PATH, 'mytest.txt')
+            writeFileSync(testPath, new Date(Date.now()).toISOString())
+            resolve(`${VIDEO_CACHE_API_STORE_BLOB} api test worked! Wrote to ${testPath}`)
         } else if (Array.isArray(args)
             && args.length === 3
             && typeof args[0] === 'string' 

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -3,18 +3,18 @@ import { writeFileSync, writeFile, mkdirSync, readFileSync, readFile } from 'fs'
 import { basename, dirname, join } from 'path'
 
 const PERSISTENT_STORAGE_PATH = join(app.getPath('userData'), 'persistentStorage')
+const VIDEO_CACHE_PATH = join(PERSISTENT_STORAGE_PATH, 'VideoCache')
 
-ipcMain.handle('testReadFile', async (_, arg) => {
+ipcMain.handle('tryRetrieveVideoBlob', async (_, args) => {
     return new Promise(function (resolve, reject) {
         // do stuff
-        if (arg === 'test') {
+        if (args === 'test') {
             resolve('test worked!')
-        } else if (Array.isArray(arg)) {
-            const [path, seqNum] = arg
-            const videosFolder = join(PERSISTENT_STORAGE_PATH, 'VideoCache')
+        } else if (Array.isArray(args)) {
+            const [path, seqNum] = args
             const relativeVideoPath = dirname(path)
             const fileName = `${basename(path)}-${seqNum}`
-            const fullFolder = join(videosFolder, relativeVideoPath)
+            const fullFolder = join(VIDEO_CACHE_PATH, relativeVideoPath)
             const fullPath = join(fullFolder, fileName)
             readFile(fullPath, (error, buffer) => {
                 if (error) {
@@ -48,20 +48,18 @@ ipcMain.handle('testReadFile', async (_, arg) => {
     })
 })
 
-ipcMain.handle('testWriteFile', async (_, arg) => {
+ipcMain.handle('storeVideoBlob', async (_, args) => {
     return new Promise(function (resolve, reject) {
         // do stuff
-        if (arg === 'test') {
-            const videosFolder = join(PERSISTENT_STORAGE_PATH, 'VideoCache')
-            mkdirSync(videosFolder, { recursive: true })
-            writeFileSync(join(videosFolder, 'mytest.txt'), 'test worked!')
+        if (args === 'test') {
+            mkdirSync(VIDEO_CACHE_PATH, { recursive: true })
+            writeFileSync(join(VIDEO_CACHE_PATH, 'mytest.txt'), 'test worked!')
             resolve('test worked!')
-        } else if (Array.isArray(arg)) {
-            const [path, seqNum, arrayBuffer] = arg
-            const videosFolder = join(PERSISTENT_STORAGE_PATH, 'VideoCache')
+        } else if (Array.isArray(args)) {
+            const [path, seqNum, arrayBuffer] = args
             const relativeVideoPath = dirname(path)
             const fileName = `${basename(path)}-${seqNum}`
-            const fullFolder = join(videosFolder, relativeVideoPath)
+            const fullFolder = join(VIDEO_CACHE_PATH, relativeVideoPath)
             const fullPath = join(fullFolder, fileName)
             mkdirSync(fullFolder, { recursive: true })
             const buffer = Buffer.from(arrayBuffer)
@@ -70,7 +68,7 @@ ipcMain.handle('testWriteFile', async (_, arg) => {
                     console.error('An error occurred:', err.message)
                     reject(err)
                 } else {
-                    resolve({ path, seqNum, videosFolder, relativeVideoPath, fileName, fullPath, bufferLength: buffer.length })
+                    resolve({ path, seqNum, videosFolder: VIDEO_CACHE_PATH, relativeVideoPath, fileName, fullPath, bufferLength: buffer.length })
                 }
             })
         } else {

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -2,6 +2,8 @@ import { ipcMain, app } from 'electron'
 import { writeFileSync, mkdirSync, readFileSync } from 'fs'
 import { basename, dirname, join } from 'path'
 
+const PERSISTENT_STORAGE_PATH = join(app.getPath('userData'), 'persistentStorage')
+
 ipcMain.handle('testReadFile', async (_, arg) => {
     return new Promise(function (resolve, reject) {
         // do stuff
@@ -9,7 +11,7 @@ ipcMain.handle('testReadFile', async (_, arg) => {
             resolve('test worked!')
         } else if (Array.isArray(arg)) {
             const [path, seqNum] = arg
-            const videosFolder = join(app.getPath('userData'), 'fullStorage', 'VideoCache')
+            const videosFolder = join(PERSISTENT_STORAGE_PATH, 'VideoCache')
             const relativeVideoPath = dirname(path)
             const fileName = `${basename(path)}-${seqNum}`
             const fullFolder = join(videosFolder, relativeVideoPath)
@@ -37,13 +39,13 @@ ipcMain.handle('testWriteFile', async (_, arg) => {
     return new Promise(function (resolve, reject) {
         // do stuff
         if (arg === 'test') {
-            const videosFolder = join(app.getPath('userData'), 'fullStorage', 'VideoCache')
+            const videosFolder = join(PERSISTENT_STORAGE_PATH, 'VideoCache')
             mkdirSync(videosFolder, { recursive: true })
             writeFileSync(join(videosFolder, 'mytest.txt'), 'test worked!')
             resolve('test worked!')
         } else if (Array.isArray(arg)) {
             const [path, seqNum, arrayBuffer] = arg
-            const videosFolder = join(app.getPath('userData'), 'fullStorage', 'VideoCache')
+            const videosFolder = join(PERSISTENT_STORAGE_PATH, 'VideoCache')
             const relativeVideoPath = dirname(path)
             const fileName = `${basename(path)}-${seqNum}`
             const fullFolder = join(videosFolder, relativeVideoPath)

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -1,0 +1,12 @@
+import { ipcMain } from 'electron'
+
+ipcMain.handle('myfunc', async (_, arg) => {
+    return new Promise(function (resolve, reject) {
+        // do stuff
+        if (arg === 'test') {
+            resolve('test worked!')
+        } else {
+            reject('this did NOT work!')
+        }
+    })
+})

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -1,9 +1,14 @@
-import { ipcMain } from 'electron'
+import { ipcMain, app } from 'electron'
+import { writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
 
-ipcMain.handle('myfunc', async (_, arg) => {
+ipcMain.handle('testWriteFile', async (_, arg) => {
     return new Promise(function (resolve, reject) {
         // do stuff
         if (arg === 'test') {
+            const videosFolder = join(app.getPath('userData'), 'fullStorage', 'VideoCache')
+            mkdirSync(videosFolder, { recursive: true })
+            writeFileSync(join(videosFolder, 'mytest.txt'), 'test worked!')
             resolve('test worked!')
         } else {
             reject('this did NOT work!')

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -1,6 +1,37 @@
 import { ipcMain, app } from 'electron'
-import { writeFileSync, mkdirSync } from 'fs'
+import { writeFileSync, mkdirSync, readFileSync } from 'fs'
 import { basename, dirname, join } from 'path'
+
+ipcMain.handle('testReadFile', async (_, arg) => {
+    return new Promise(function (resolve, reject) {
+        // do stuff
+        if (arg === 'test') {
+            resolve('test worked!')
+        } else if (Array.isArray(arg)) {
+            const [path, seqNum] = arg
+            const videosFolder = join(app.getPath('userData'), 'fullStorage', 'VideoCache')
+            const relativeVideoPath = dirname(path)
+            const fileName = `${basename(path)}-${seqNum}`
+            const fullFolder = join(videosFolder, relativeVideoPath)
+            const fullPath = join(fullFolder, fileName)
+            try {
+                const buffer = readFileSync(fullPath)
+                resolve(buffer)
+            } catch (error) {
+                if (error.code === 'ENOENT') {
+                    resolve(null)
+                } else {
+                    // Handle other possible errors
+                    console.error('An error occurred:', error.message)
+                    reject(error)
+                }
+            }
+
+        } else {
+            reject('this did NOT work!')
+        }
+    })
+})
 
 ipcMain.handle('testWriteFile', async (_, arg) => {
     return new Promise(function (resolve, reject) {

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -1,6 +1,6 @@
 import { ipcMain, app } from 'electron'
 import { writeFileSync, mkdirSync } from 'fs'
-import { join } from 'path'
+import { basename, dirname, join } from 'path'
 
 ipcMain.handle('testWriteFile', async (_, arg) => {
     return new Promise(function (resolve, reject) {
@@ -10,6 +10,17 @@ ipcMain.handle('testWriteFile', async (_, arg) => {
             mkdirSync(videosFolder, { recursive: true })
             writeFileSync(join(videosFolder, 'mytest.txt'), 'test worked!')
             resolve('test worked!')
+        } else if (Array.isArray(arg)) {
+            const [path, seqNum, arrayBuffer] = arg
+            const videosFolder = join(app.getPath('userData'), 'fullStorage', 'VideoCache')
+            const relativeVideoPath = dirname(path)
+            const fileName = `${basename(path)}-${seqNum}`
+            const fullFolder = join(videosFolder, relativeVideoPath)
+            const fullPath = join(fullFolder, fileName)
+            mkdirSync(fullFolder, { recursive: true })
+            const buffer = Buffer.from(arrayBuffer)
+            writeFileSync(fullPath, buffer)
+            resolve({ path, seqNum, videosFolder, relativeVideoPath, fileName, fullPath, bufferLength: buffer.length })
         } else {
             reject('this did NOT work!')
         }


### PR DESCRIPTION
What issue(s) is this trying to resolve?
* feat(sltt-app): add contextBridge api for storing videos to local disk (outside of browser) #6

How does it all work?
* added ipcMain.handle() for ipcRenderer messages `storyVideoBlob` and `tryRetrieveVideoBlob`
* blobs are actually read/written using ArrayBuffers
* store (and get) video blobs under `%APPDATA%/sltt-app/persistentStorage/{projectName}/{_id}/{blob-num}` (see [app.getPath docs](https://www.electronjs.org/docs/latest/api/app#appgetpathname))
* `storeVideoBlob` will return debug information about video file paths and buffer length.
* `tryRetrieveVideoBlob` will return the arrayBuffer for the file if found, otherwise it returns null for file not found error, otherwise throws an error. (`try` in `tryRetrieveVideoBlob` interface means return null if not found)
* Both interfaces try to throw type errors found in the args

What particularly has changed?
* update `electron-vite-config.ts` so storage/index.ts gets compiled and included in build in `out/main/storage.js`
* update version to 205104.0.22-alpha1 (2.51.4)
* import `./storage.js`
* add storage/index.ts to define ipcMain handlers for `storeVideoBlob` and `tryRetrieveVideoBlob` messages

Steps for testing
1. With dev console open (control+shift+i) follow test [steps in client changes PR](https://github.com/ubsicap/sltt/pull/840) and filter on `SlttAppStorage` to see logs 

https://github.com/ubsicap/sltt-app/assets/1125565/2ad324b5-3fe9-4184-9d43-41b87d404d54

ticket: https://github.com/ubsicap/sltt-app/issues/6
commit-convention: https://www.conventionalcommits.org/en/v1.0.0/
