### PR TITLE
feat(sltt-app): store docs outside of browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sltt-app",
-  "version": "205104.0.22-alpha1",
+  "version": "205300.0.23-alpha1",
   "description": "Installable SLTT app (Sign Language Translation Tool)",
   "main": "./out/main/index.js",
   "author": "sltt-bible.net",
@@ -19,8 +19,8 @@
     "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
-    "find:version:source": "findstr /S /M /C:\"version:\\\"2.51.4\\\"\" %SLTT_CLIENT_DIR%/build/static/js/main.*.chunk.js",
-    "find:version:target": "findstr /S /M /C:\"version:\\\"2.51.4\\\"\" out\\client\\static\\js\\main.*.chunk.js",
+    "find:version:source": "findstr /S /M /C:\"version:\\\"2.53.0\\\"\" %SLTT_CLIENT_DIR%/build/static/js/main.*.chunk.js",
+    "find:version:target": "findstr /S /M /C:\"version:\\\"2.53.0\\\"\" out\\client\\static\\js\\main.*.chunk.js",
     "find:auth0_client_id:target": "findstr /S /M /C:\"REACT_APP_AUTH0_CLIENT_ID:\\\"eTewsjcscudtGHteG3u86YEDwHUTRd6Z\\\"\" out\\client\\static\\js\\main.*.chunk.js",
     "find:auth0_client_id:source": "findstr /S /M /C:\"REACT_APP_AUTH0_CLIENT_ID:\\\"eTewsjcscudtGHteG3u86YEDwHUTRd6Z\\\"\" %SLTT_CLIENT_DIR%/build/static/js/main.*.chunk.js",
     "rmdir:build:client": "if exist .\\out\\client rmdir /s /q .\\out\\client",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,7 @@ import icon from '../../resources/icon.png?asset'
 function createWindow(): BrowserWindow {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
-    width: 900,
+    width: 1400,
     height: 670,
     show: false,
     autoHideMenuBar: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,9 @@ function createWindow(): BrowserWindow {
     }
   })
 
+  // Maximize the window
+  mainWindow.maximize()
+
   mainWindow.on('ready-to-show', () => {
     mainWindow.show()
   })

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -183,7 +183,17 @@ ipcMain.handle(DOCS_API_LIST_DOCS, async (_, args) => {
         ) {
             console.log('listDocs args:', args)
             const { project, isFromRemote } = args
-            listDocs({ project, isFromRemote }).then(resolve).catch(reject)
+            listDocs({ project, isFromRemote }).then(filenames => {
+               if (!isFromRemote) {
+                  const localFilenames = []
+                  // get remote docs
+                  // for each local doc compose remote filename and see if that file exists
+                  // if so stop local filenames
+                  resolve(localFilenames)
+               } else {
+                  resolve(filenames)
+               }
+            }).catch(reject)
         } else {
             reject(`invalid args for ${DOCS_API_LIST_DOCS}. Expected: '{ project: string, isFromRemote: boolean }' Got: ${JSON.stringify(args)}`)
         }

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -114,9 +114,10 @@ ipcMain.handle(DOCS_API_PUT_DOC, async (_, args) => {
             resolve(`${DOCS_API_PUT_DOC} api test worked!`)
         } else if (Array.isArray(args)
             && args.length === 2
-            && typeof args[0] === 'object') {
-            const [doc] = args
-            // is remote doc or local?
+            && typeof args[0] === 'object'
+            && typeof args[1] === 'string') {
+            const [doc, remoteSeq] = args
+            const fullFromPath = remoteSeq ? DOCS_FROM_REMOTE_PATH : DOCS_FROM_LOCAL_PATH
             const { _id, modDate, creator, modBy } = doc as { _id: string, modDate: string, creator: string, modBy: string }
             // TODO: make path safe as filename
             const filenameSafeModDate = getFilenameSafeDate(modDate)
@@ -124,8 +125,8 @@ ipcMain.handle(DOCS_API_PUT_DOC, async (_, args) => {
             const filenameSafeCreator = getFilenameSafeEmail(creator)
             const filenameSafeModBy = modBy && getFilenameSafeEmail(modBy) || 'no-mod-by'
             const filename = `${filenameSafeModDate}__${filenameSafeId}__${filenameSafeCreator}__${filenameSafeModBy}`
-            mkdirSync(DOCS_FROM_REMOTE_PATH, { recursive: true })
-            const fullPath = join(DOCS_FROM_REMOTE_PATH, DOCS_FROM_REMOTE_PATH)
+            mkdirSync(fullFromPath, { recursive: true })
+            const fullPath = join(fullFromPath, filename)
             writeFile(fullPath, doc, (err) => {
                 if (err) {
                     console.error('An error occurred:', err.message)

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -99,13 +99,11 @@ const getFilenameSafeId = (_id: string): string => {
 
 
 const createMd5Hash = (s: string): string => createHash('md5').update(s).digest('hex').toString()
-const createEmailHash = (email: string): string => createMd5Hash(email).substring(0, 16)
+const createEmailHash = (email: string): string => createMd5Hash(email).substring(0, 16) // api uses this
 
 const getFilenameSafeEmail = (email: string): string => {
-    return createEmailHash(email)
+    return createEmailHash(email).substring(0, 8) // 8 characters will probably avoid collision within team 
 }
-
-
 
 ipcMain.handle(DOCS_API_STORE_DOC, async (_, args) => {
     return new Promise(function (resolve, reject) {

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -158,9 +158,11 @@ ipcMain.handle(DOCS_API_LIST_DOCS, async (_, args) => {
     return new Promise(function (resolve, reject) {
         if (args === 'test') {
             resolve(`${DOCS_API_LIST_DOCS} api test worked!`)
-        } else if (typeof args === 'boolean') {
+        } else if (typeof args === 'object'
+            && 'isFromRemote' in args && typeof args.isFromRemote === 'boolean'
+        ) {
             console.log('listDocs args:', args)
-            const isFromRemote = args
+            const { isFromRemote } = args
             const fullFromPath = isFromRemote ? DOCS_FROM_REMOTE_PATH : DOCS_FROM_LOCAL_PATH
             // detect if path doesn't yet exist
             if (!existsSync(fullFromPath)) {
@@ -188,7 +190,7 @@ ipcMain.handle(DOCS_API_LIST_DOCS, async (_, args) => {
                 }
             })
         } else {
-            reject(`invalid args for ${DOCS_API_LIST_DOCS}. Expected: 'boolean' Got: ${JSON.stringify(args)}`)
+            reject(`invalid args for ${DOCS_API_LIST_DOCS}. Expected: '{ isFromRemote: boolean }' Got: ${JSON.stringify(args)}`)
         }
     })
 })

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -124,10 +124,10 @@ ipcMain.handle(DOCS_API_PUT_DOC, async (_, args) => {
             const filenameSafeCreator = getFilenameSafeEmail(creator)
             const filenameSafeModBy = modBy && getFilenameSafeEmail(modBy) || 'no-mod-by'
             const filenameRemoteSeq = remoteSeq ? `${remoteSeq}__` : ''
-            const filename = `${filenameRemoteSeq}${filenameSafeModDate}__${filenameSafeId}__${filenameSafeCreator}__${filenameSafeModBy}`
+            const filename = `${filenameRemoteSeq}${filenameSafeModDate}__${filenameSafeId}__${filenameSafeCreator}__${filenameSafeModBy}.sltt-doc`
             mkdirSync(fullFromPath, { recursive: true })
             const fullPath = join(fullFromPath, filename)
-            writeFile(fullPath, doc, (err) => {
+            writeFile(fullPath, JSON.stringify(doc), (err) => {
                 if (err) {
                     console.error('An error occurred:', err.message)
                     reject(err)
@@ -136,7 +136,7 @@ ipcMain.handle(DOCS_API_PUT_DOC, async (_, args) => {
                 }
             })
         } else {
-            reject(`invalid args for ${DOCS_API_PUT_DOC}. Expected: [path: string, content: string] Got: ${JSON.stringify(args)}`)
+            reject(`invalid args for ${DOCS_API_PUT_DOC}. Expected: [doc: string, remoteSeq: string] Got: ${JSON.stringify(args)}`)
         }
     })
 })

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -200,7 +200,7 @@ ipcMain.handle(DOCS_API_LIST_DOCS, async (_, args) => {
                         if (strippedRemoteFilenames.has(strippedLocalFilename)) {
                             break
                         }
-                        localFilenames.push(localFilename)
+                        localFilenames.unshift(localFilename) // undo reverse order
                     }
                     resolve(localFilenames)
                 } else {

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -111,7 +111,7 @@ const composeFilename = (modDate: string, _id: string, creator: string, modBy: s
     const filenameSafeId = getFilenameSafeId(_id)
     const filenameSafeCreator = getFilenameSafeEmail(creator)
     const filenameSafeModBy = modBy && getFilenameSafeEmail(modBy) || 'no-mod-by'
-    const filenameRemoteSeq = remoteSeq ? `${remoteSeq}__` : ''
+    const filenameRemoteSeq = remoteSeq ? `${remoteSeq.padStart(9, '0')}__` : ''
     const filename = `${filenameRemoteSeq}${filenameSafeModDate}__${filenameSafeId}__${filenameSafeCreator}__${filenameSafeModBy}.sltt-doc`
     return filename
 }

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -11,7 +11,7 @@ const DOCS_FROM_LOCAL_PATH = join(DOCS_PATH, 'local')
 
 const VIDEO_CACHE_API_STORE_BLOB = 'storeVideoBlob'
 const VIDEO_CACHE_API_TRY_RETRIEVE_BLOB = 'tryRetrieveVideoBlob'
-const DOCS_API_PUT_DOC = 'putDoc'
+const DOCS_API_STORE_DOC = 'storeDoc'
 
 ipcMain.handle(VIDEO_CACHE_API_TRY_RETRIEVE_BLOB, async (_, args) => {
     return new Promise(function (resolve, reject) {
@@ -107,11 +107,11 @@ const getFilenameSafeEmail = (email: string): string => {
 
 
 
-ipcMain.handle(DOCS_API_PUT_DOC, async (_, args) => {
+ipcMain.handle(DOCS_API_STORE_DOC, async (_, args) => {
     return new Promise(function (resolve, reject) {
         // do stuff
         if (args === 'test') {
-            resolve(`${DOCS_API_PUT_DOC} api test worked!`)
+            resolve(`${DOCS_API_STORE_DOC} api test worked!`)
         } else if (Array.isArray(args)
             && args.length === 2
             && typeof args[0] === 'object'
@@ -136,7 +136,7 @@ ipcMain.handle(DOCS_API_PUT_DOC, async (_, args) => {
                 }
             })
         } else {
-            reject(`invalid args for ${DOCS_API_PUT_DOC}. Expected: [doc: string, remoteSeq: string] Got: ${JSON.stringify(args)}`)
+            reject(`invalid args for ${DOCS_API_STORE_DOC}. Expected: [doc: string, remoteSeq: string] Got: ${JSON.stringify(args)}`)
         }
     })
 })

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -234,6 +234,7 @@ async function listDocs({ project, isFromRemote }: { project: string, isFromRemo
                 console.log('filenames:', filenames)
                 const result = filenames
                     .filter(filename => filename.endsWith('.sltt-doc'))
+                result.sort() // just in case it's not yet by name
                 console.log('listDocs result:', result)
                 resolve(result)
             }

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -177,7 +177,7 @@ ipcMain.handle(DOCS_API_LIST_DOCS, async (_, args) => {
                         .filter(filename => filename.endsWith('.sltt-doc'))
                         .map(filename => {
                             if (isFromRemote) {
-                                const [remoteSeq, modDate] = filename.split('__').slice(0, 1)
+                                const [remoteSeq, modDate] = filename.split('__').slice(0, 2)
                                 return { modDate, remoteSeq }
                             }
                             const modDate = filename.split('__')[0]

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -132,7 +132,7 @@ ipcMain.handle(DOCS_API_PUT_DOC, async (_, args) => {
                     console.error('An error occurred:', err.message)
                     reject(err)
                 } else {
-                    resolve({ filename, doc, fullPath, _id, modDate, creator, modBy })
+                    resolve({ remoteSeq, filename, doc, fullPath, _id, modDate, creator, modBy })
                 }
             })
         } else {

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -119,12 +119,12 @@ ipcMain.handle(DOCS_API_PUT_DOC, async (_, args) => {
             const [doc, remoteSeq] = args
             const fullFromPath = remoteSeq ? DOCS_FROM_REMOTE_PATH : DOCS_FROM_LOCAL_PATH
             const { _id, modDate, creator, modBy } = doc as { _id: string, modDate: string, creator: string, modBy: string }
-            // TODO: make path safe as filename
             const filenameSafeModDate = getFilenameSafeDate(modDate)
             const filenameSafeId = getFilenameSafeId(_id)
             const filenameSafeCreator = getFilenameSafeEmail(creator)
             const filenameSafeModBy = modBy && getFilenameSafeEmail(modBy) || 'no-mod-by'
-            const filename = `${filenameSafeModDate}__${filenameSafeId}__${filenameSafeCreator}__${filenameSafeModBy}`
+            const filenameRemoteSeq = remoteSeq ? `${remoteSeq}__` : ''
+            const filename = `${filenameRemoteSeq}${filenameSafeModDate}__${filenameSafeId}__${filenameSafeCreator}__${filenameSafeModBy}`
             mkdirSync(fullFromPath, { recursive: true })
             const fullPath = join(fullFromPath, filename)
             writeFile(fullPath, doc, (err) => {


### PR DESCRIPTION
What issue(s) is this trying to resolve?
* feat(sltt-app): store docs outside of browser #13

How does it all work?
* added handlers for handling channels for `storeDocs`, `listDocs` and `retrieveDoc`
* `storeDoc` (project, doc, remoteSeq) stringifies doc and stores each in filename safe version of {`/docs/{project}/{remote-seq}|local-doc__{modDate}__{id}__{creator}__{modBy}
* for filesafety, if a filename becomes over 255 characters, we switch to a shorter convention for storing ids, so that times are separated by hyphens without the date part
* `listDocs` (project, isFromRemote) gives list of remote or local filenames. For local docs it starts with the most recent modDates and gets a list of the remote docs and will stop when it finds a corresponding remoteDoc.  
* Remote seq is padded to 9 zeros and `local-doc` is 9 characters to make it trivial to find corresponding remoteDoc match to local-doc. (Otherwise, we'd need to also match on an abbreviated format for remoteDoc just in case).
* `retrieveDoc` (project, isFromRemote, filename) returns the doc according to the filename

What particularly has changed?
* bumped version to `205300.0.23-alpha1` (2.53.0 / 0.23)

Steps for testing
1. Install https://github.com/ubsicap/sltt-app/releases/download/v205104.0.22-alpha1/sltt-app.Setup.205104.0.22-alpha1.exe
2. With the internet on, go to Settings > Debug > Clear local database
This will re-download all the changes from the remote database and will store a copy of each in `%AppData%/sltt-app/persistentStorage/docs/remote`
3. Now disconnect from the internet
4. Make a couple of simple text changes (add a text note). Expect those changes to show up in `%AppData%/sltt-app/persistentStorage/docs/local`
5. While offline, go to Settings > Debug > Clear local database
6. Wait until the app loads and verify the recent offline changes are still there

https://github.com/ubsicap/sltt-app/assets/1125565/d646e3c1-9ac9-41d6-92eb-2aee03290b8c

ticket: https://github.com/ubsicap/sltt-app/issues/13
commit-convention: https://www.conventionalcommits.org/en/v1.0.0/
