### PR TITLE
feat(sltt-app): save/restore video cache records to/from disk

### DIFF
--- a/storage/index.ts
+++ b/storage/index.ts
@@ -131,9 +131,10 @@ ipcMain.handle(VIDEO_CACHE_RECORDS_API_LIST_VCRS, async (_, args) => {
                     }
                 } else {
                     const { project } = args
+                    // empty project means all projects
                     const result = filenames
                         .filter(filename =>
-                            filename.startsWith(`${project}__`) &&
+                            (!project || filename.startsWith(`${project}__`)) &&
                             filename.endsWith('.sltt-vcr')
                         )
                     result.sort() // just in case it's not yet by name

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -12,7 +12,7 @@ const VIDEO_CACHE_API_STORE_BLOB = 'storeVideoBlob'
 const VIDEO_CACHE_API_TRY_RETRIEVE_BLOB = 'tryRetrieveVideoBlob'
 const VIDEO_CACHE_RECORDS_API_STORE_VCR = 'storeVideoCacheRecord'
 const VIDEO_CACHE_RECORDS_API_LIST_VCRS = 'listVideoCacheRecords'
-const VIDEO_CACHE_RECORDS_API_TRY_RETRIEVE_VCR = 'tryRetrieveVideoCacheRecord'
+const VIDEO_CACHE_RECORDS_API_RETRIEVE_VCR = 'retrieveVideoCacheRecord'
 const DOCS_API_STORE_DOC = 'storeDoc'
 const DOCS_API_LIST_DOCS = 'listDocs'
 const DOCS_API_RETRIEVE_DOC = 'retrieveDoc'
@@ -146,29 +146,25 @@ ipcMain.handle(VIDEO_CACHE_RECORDS_API_LIST_VCRS, async (_, args) => {
     })
 })
 
-ipcMain.handle(VIDEO_CACHE_RECORDS_API_TRY_RETRIEVE_VCR, async (_, args) => {
+ipcMain.handle(VIDEO_CACHE_RECORDS_API_RETRIEVE_VCR, async (_, args) => {
     return new Promise(function (resolve, reject) {
         if (args === 'test') {
-            resolve(`${VIDEO_CACHE_RECORDS_API_TRY_RETRIEVE_VCR} api test worked!`)
+            resolve(`${VIDEO_CACHE_RECORDS_API_RETRIEVE_VCR} api test worked!`)
         } else if (typeof args === 'object'
-            && 'filename' in args && typeof args.videoCacheRecordId === 'string') {
+            && 'filename' in args && typeof args.filename === 'string') {
             const { filename } = args
             const fullPath = join(VIDEO_CACHE_RECORDS_PATH, filename)
             readFile(fullPath, (error, buffer) => {
                 if (error) {
-                    if (error.code === 'ENOENT') {
-                        resolve(null)
-                    } else {
-                        console.error('An error occurred:', error.message)
-                        reject(error)
-                    }
+                    console.error('An error occurred:', error.message)
+                    reject(error)
                 } else {
                     const videoCacheRecord = JSON.parse(buffer.toString())
                     resolve(videoCacheRecord)
                 }
             })
         } else {
-            reject(`invalid args for ${VIDEO_CACHE_RECORDS_API_TRY_RETRIEVE_VCR}. Expected: { videoCacheRecordId: string } Got: ${JSON.stringify(args)}`)
+            reject(`invalid args for ${VIDEO_CACHE_RECORDS_API_RETRIEVE_VCR}. Expected: { filename: string } Got: ${JSON.stringify(args)}`)
         }
     })
 })

--- a/storage/index.ts
+++ b/storage/index.ts
@@ -11,7 +11,7 @@ const DOCS_PATH = join(PERSISTENT_STORAGE_PATH, 'docs')
 const VIDEO_CACHE_API_STORE_BLOB = 'storeVideoBlob'
 const VIDEO_CACHE_API_TRY_RETRIEVE_BLOB = 'tryRetrieveVideoBlob'
 const VIDEO_CACHE_PENDING_UPLOADS_API_STORE_PENDING_UPLOAD_VCR = 'storeVideoPendingUploadVideoCacheRecord'
-const VIDEO_CACHE_PENDING_UPLOADS_API_RETRIEVE_PENDING_UPLOAD_VCR = 'retrieveVideoPendingUploadVideoCacheRecord'
+const VIDEO_CACHE_PENDING_UPLOADS_API_TRY_RETRIEVE_PENDING_UPLOAD_VCR = 'tryRetrieveVideoPendingUploadVideoCacheRecord'
 const VIDEO_CACHE_PENDING_UPLOADS_API_TRY_REMOVE_PENDING_UPLOAD_VCR = 'tryRemoveVideoPendingUploadVideoCacheRecord'
 const DOCS_API_STORE_DOC = 'storeDoc'
 const DOCS_API_LIST_DOCS = 'listDocs'
@@ -115,10 +115,10 @@ ipcMain.handle(VIDEO_CACHE_PENDING_UPLOADS_API_STORE_PENDING_UPLOAD_VCR, async (
     })
 })
 
-ipcMain.handle(VIDEO_CACHE_PENDING_UPLOADS_API_RETRIEVE_PENDING_UPLOAD_VCR, async (_, args) => {
+ipcMain.handle(VIDEO_CACHE_PENDING_UPLOADS_API_TRY_RETRIEVE_PENDING_UPLOAD_VCR, async (_, args) => {
     return new Promise(function (resolve, reject) {
         if (args === 'test') {
-            resolve(`${VIDEO_CACHE_PENDING_UPLOADS_API_RETRIEVE_PENDING_UPLOAD_VCR} api test worked!`)
+            resolve(`${VIDEO_CACHE_PENDING_UPLOADS_API_TRY_RETRIEVE_PENDING_UPLOAD_VCR} api test worked!`)
         } else if (typeof args === 'object'
             && 'videoCacheRecordId' in args && typeof args.videoCacheRecordId === 'string') {
             const { videoCacheRecordId } = args
@@ -126,15 +126,19 @@ ipcMain.handle(VIDEO_CACHE_PENDING_UPLOADS_API_RETRIEVE_PENDING_UPLOAD_VCR, asyn
             const fullPath = join(VIDEO_CACHE_PENDING_UPLOADS_PATH, filename)
             readFile(fullPath, (error, buffer) => {
                 if (error) {
-                    console.error('An error occurred:', error.message)
-                    reject(error)
+                    if (error.code === 'ENOENT') {
+                        resolve(null)
+                    } else {
+                        console.error('An error occurred:', error.message)
+                        reject(error)
+                    }
                 } else {
                     const videoCacheRecord = JSON.parse(buffer.toString())
                     resolve(videoCacheRecord)
                 }
             })
         } else {
-            reject(`invalid args for ${VIDEO_CACHE_PENDING_UPLOADS_API_RETRIEVE_PENDING_UPLOAD_VCR}. Expected: { videoCacheRecordId: string } Got: ${JSON.stringify(args)}`)
+            reject(`invalid args for ${VIDEO_CACHE_PENDING_UPLOADS_API_TRY_RETRIEVE_PENDING_UPLOAD_VCR}. Expected: { videoCacheRecordId: string } Got: ${JSON.stringify(args)}`)
         }
     })
 })


### PR DESCRIPTION
What issue(s) is this trying to resolve?
* feat(sltt-app): save/restore video cache records to/from disk #14

How does it all work?
* define vide cache records path `%APPDATA%\sltt-app\persitentStorage\VideoCacheRecords`. This mimics the browser VideoCache > cachedVideos store for all projects
* define ipc channel handlers for video cache record api (see client implementation here https://github.com/ubsicap/sltt/pull/846): 
  - `storeVideoCacheRecord` with args `({ videoCacheRecord })`
  - `listVideoCacheRecords` with args `({ project })` where project can be empty to get vcrs across all project, 
  - `retrieveVideoCacheRecord` with args `({ filename })`
* store video cache records using the convention `{project}__{dashed-id}-{parts}.sltt-vcr`, where {dashed-id} transforms `/` to `-` (e.g. `BGSL_БЖЕ/230601_064416/230601_065151/240327_114822-2` converts to `BGSL_БЖЕ__230601_064416-230601_065151-240327_114822-2.sltt-vcr`)

Steps for testing
1. install latest release
2. go offline
3. record and save video. Expect to see pending upload icon (and register in Settings > Uploads report)
4. go to Settings > Debug > Clear Video Cache!!!
5. Restart sltt-app (still offline)
6. Expect pending upload icon should still be showing after initialization
7. Go online and the upload should successfully upload so video can be seen/shared with other team members or at https://sltt-bible.net

ticket: https://github.com/ubsicap/sltt-app/issues/14
commit-convention: https://www.conventionalcommits.org/en/v1.0.0/