### PR TITLE
feat(sltt-app): add multiple private window support

### DIFF
--- a/compressor/index.js
+++ b/compressor/index.js
@@ -114,7 +114,7 @@ app.get('/metadata', async (req, res, next) => {
     }
 })
 
-app.get('/freeSpace', async (req, res, next) => {
+app.get('/freeSpace', async (_req, res, /* next */) => {
     let space = await checkDiskSpace(_config.videosPath)
     res.send({ free: space.free })
 })

--- a/compressor/src/VideoCompressor.js
+++ b/compressor/src/VideoCompressor.js
@@ -10,7 +10,6 @@ let { ffmpegPath } = _config
 ffmpeg.setFfmpegPath(ffmpegPath)
 
 const bytesToMB = bytes => (bytes / (1024 * 1024)).toFixed(1)
-const { basename } = path
 
 class VideoCompressor {
     compress = async (inputFilePath, outputFilePath, ffmpegParameters) => {
@@ -18,7 +17,8 @@ class VideoCompressor {
         let progressTracker = new ProgressNotifier(outputFilePath)
         try {
             let s = fs.statSync(inputFilePath)
-            console.log(`Compress starting: ${basename(inputFilePath)} (${bytesToMB(s.size)}MB)`)
+            const filePathWithParentFolder = `${inputFilePath.split(path.sep).slice(-2).join(path.sep)}`
+            console.log(`Compress starting: ${filePathWithParentFolder} (${bytesToMB(s.size)}MB)`)
             
             let stats = await FfmpegWrapper.compress(inputFilePath, outputFilePath, ffmpegParameters, progressTracker)
             
@@ -34,10 +34,11 @@ class VideoCompressor {
         progressMap.set(outputFilePath, new ProgressEntry())
         let progressTracker = new ProgressNotifier(outputFilePath)
         try {
-            console.log(`Join segments [${filePaths.length}, ${basename(outputFilePath)}`)
-            let { videosPath } = _config
+            const filePathWithParentFolder = `${outputFilePath.split(path.sep).slice(-2).join(path.sep)}`
+            console.log(`Join segments [${filePaths.length}, ${filePathWithParentFolder}]`)
             
-            let concatTextFilePath = path.join(videosPath, `${new Date().getTime()}-concat.txt`)
+            const clientDir = path.dirname(filePaths[0])
+            let concatTextFilePath = path.join(clientDir, `${new Date().getTime()}-concat.txt`)
             await FfmpegWrapper.createConcatFile(filePaths, concatTextFilePath)
             let stats = await FfmpegWrapper.concatenate(concatTextFilePath, outputFilePath)
             

--- a/compressor/src/config.js
+++ b/compressor/src/config.js
@@ -13,8 +13,8 @@ let path = require('path')
 // To make sure ffmpeg files got installed as expected:
 // http://localhost:29678/ffmpeg/stats
 
-const tmpDirectory = path.join(os.tmpdir(), '/compression-server')
-console.log(`Temporary directory: ${tmpDirectory}`)
+const tmpDirectory = path.join(os.tmpdir(), '/sltt-app/server-29678')
+console.log(`sltt-app server temp directory: ${tmpDirectory}`)
 
 const resourcesPath = path.join(tmpDirectory, '/resources')
 const videosPath = path.join(tmpDirectory, '/videos')
@@ -35,7 +35,7 @@ console.log(`srcFfmpegPath: ${srcFfmpegPath}`)
 
 const ffmpegPath = path.join(resourcesPath, `/ffmpeg-x64${getFileExtension()}`)
 
-const version = '1.1.0'
-console.log(`Compressor Version: ${version}`)
+const version = '2.0.0'
+console.log(`sltt-app server version: ${version}`)
 
 module.exports = { resourcesPath, videosPath, srcFfmpegPath, ffmpegPath, version, platform }

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -18,11 +18,20 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()]
   },
   renderer: {
+    logLevel: 'info',
     resolve: {
       alias: {
         '@renderer': resolve('src/renderer/src')
       }
     },
-    plugins: [react()]
+    plugins: [react()],
+    build: {
+      rollupOptions: {
+        input: {
+          main: resolve(__dirname, 'src/renderer/index.html'),
+          newPrivateWindow: resolve(__dirname, 'src/renderer/dialogs/newPrivateWindow.html')
+        }
+      }
+    }
   }
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,6 +38,7 @@ function createWindow(partition?: string): BrowserWindow {
   // Load the remote URL for development or the local html file for production.
   console.log({ loadUrl: process.env['ELECTRON_RENDERER_URL'], isDev: is.dev })
   loadUrlOrFile(win)
+  createMenu(win)
   return win
 }
 
@@ -71,8 +72,6 @@ app.whenReady().then(() => {
     const { search } = urlParts
     loadUrlOrFile(mainWindow, search ? { search } : undefined)
   })
-
-  createMenu(mainWindow)
 
   // Register a global shortcut for Alt+W
   globalShortcut.register('Alt+W', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,7 +9,7 @@ import icon from '../../resources/icon.png?asset'
 const CONFIG_FILE = join(app.getPath('userData'), 'window-configs.json')
 
 function createWindow(partition?: string): BrowserWindow {
-  const mainWindow = new BrowserWindow({
+  const win = new BrowserWindow({
     width: 1400,
     height: 670,
     show: false,
@@ -23,13 +23,13 @@ function createWindow(partition?: string): BrowserWindow {
   })
 
   // Maximize the window
-  mainWindow.maximize()
+  win.maximize()
 
-  mainWindow.on('ready-to-show', () => {
-    mainWindow.show()
+  win.on('ready-to-show', () => {
+    win.show()
   })
 
-  mainWindow.webContents.setWindowOpenHandler((details) => {
+  win.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url)
     return { action: 'deny' }
   })
@@ -37,8 +37,8 @@ function createWindow(partition?: string): BrowserWindow {
   // HMR for renderer base on electron-vite cli.
   // Load the remote URL for development or the local html file for production.
   console.log({ loadUrl: process.env['ELECTRON_RENDERER_URL'], isDev: is.dev })
-  loadUrlOrFile(mainWindow)
-  return mainWindow
+  loadUrlOrFile(win)
+  return win
 }
 
 // This method will be called when Electron has finished
@@ -184,15 +184,13 @@ function createMenu(mainWindow: BrowserWindow): void {
   const menuTemplate = [
     {
       label: '🪟',
-      tooltip: 'Configure windows',
       submenu: [
         ...configNames.map((name) => ({
           label: name,
           click: (): ReturnType<typeof createWindow> => createWindow(name)
         })),
         {
-          label: '➕🪟🕶️',
-          tooltip: 'Add new private window',
+          label: '➕🕶️',
           click: async (): Promise<void> => {
             const newConfigName = await launchNewWindowConfig(configs)
             if (newConfigName) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -176,7 +176,7 @@ function saveWindowConfigs(configs: Record<string, { partition: string }>): void
   writeFileSync(CONFIG_FILE, JSON.stringify(configs, null, 2))
 }
 
-function createMenu(mainWindow: BrowserWindow): void {
+function createMenu(win: BrowserWindow): void {
   const configs = loadWindowConfigs()
   const configNames = Object.keys(configs)
 
@@ -201,7 +201,7 @@ function createMenu(mainWindow: BrowserWindow): void {
           label: '🔧',
           tooltip: 'DevTools',
           click: (): void => {
-            mainWindow.webContents.openDevTools()
+            win.webContents.openDevTools()
           }
         },
       ]

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -210,13 +210,6 @@ function createMenu(mainWindow: BrowserWindow): void {
 
   const menu = Menu.buildFromTemplate(menuTemplate)
   Menu.setApplicationMenu(menu)
-
-  // Open DevTools when the menu is shown
-  mainWindow.webContents.on('before-input-event', (_event, input) => {
-    if (input.key === 'Alt' && input.code === 'KeyW') {
-      mainWindow.webContents.openDevTools()
-    }
-  })
 }
 
 // In this file you can include the rest of your app's specific main process

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,12 +1,14 @@
-import { app, shell, BrowserWindow, LoadFileOptions } from 'electron'
+import { app, shell, BrowserWindow, LoadFileOptions, Menu, globalShortcut, ipcMain } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { join } from 'path'
 import { parse } from 'url'
 import { optimizer, is } from '@electron-toolkit/utils'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
 import icon from '../../resources/icon.png?asset'
 
-function createWindow(): BrowserWindow {
-  // Create the browser window.
+const CONFIG_FILE = join(app.getPath('userData'), 'window-configs.json')
+
+function createWindow(partition?: string): BrowserWindow {
   const mainWindow = new BrowserWindow({
     width: 1400,
     height: 670,
@@ -15,7 +17,8 @@ function createWindow(): BrowserWindow {
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: false
+      sandbox: false,
+      partition: partition && `persist:${partition}`
     }
   })
 
@@ -58,15 +61,25 @@ app.whenReady().then(() => {
     optimizer.watchWindowShortcuts(window)
   })
 
-  const win = createWindow()
-  const { session: { webRequest } } = win.webContents
+  const mainWindow = createWindow()
+  const { session: { webRequest } } = mainWindow.webContents
 
   webRequest.onBeforeRequest({
     urls: ['http://localhost/callback*']
   }, async ({ url: callbackURL }) => {
     const urlParts = parse(callbackURL, true)
     const { search } = urlParts
-    loadUrlOrFile(win, search ? { search } : undefined)
+    loadUrlOrFile(mainWindow, search ? { search } : undefined)
+  })
+
+  createMenu(mainWindow)
+
+  // Register a global shortcut for Alt+W
+  globalShortcut.register('Alt+W', () => {
+    const menu = Menu.getApplicationMenu()
+    if (menu) {
+      menu.popup({ window: mainWindow })
+    }
   })
 
   app.on('activate', function () {
@@ -115,6 +128,100 @@ function loadUrlOrFile(mainWindow: BrowserWindow, options: LoadFileOptions | und
     mainWindow.loadFile(join(__dirname, '../client/index.html'), options)
   }
 }
+
+async function launchNewWindowConfig(configs: ReturnType<typeof loadWindowConfigs>): Promise<string> {
+  const inputWindow = new BrowserWindow({
+    width: 620,
+    height: 320,
+    modal: true,
+    parent: BrowserWindow.getFocusedWindow() || undefined,
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      sandbox: false
+    }
+  })
+
+  const emptyMenu = Menu.buildFromTemplate([])
+  inputWindow.setMenu(emptyMenu)
+  inputWindow.loadFile(join(__dirname, '../renderer/dialogs/newPrivateWindow.html'))
+  // inputWindow.webContents.openDevTools()
+
+  const [newConfigName] = await promisifyIpcEvent<string>('new-config-name')
+  if (newConfigName) {
+    configs[newConfigName] = { partition: newConfigName }
+    saveWindowConfigs(configs)
+    inputWindow.close()
+    return newConfigName
+  } else {
+    inputWindow.close()
+    return ''
+  }
+}
+
+async function promisifyIpcEvent<TResponse>(event: string): Promise<TResponse[]> {
+  return new Promise((resolve) => {
+    ipcMain.once(event, (_event, ...args) => {
+      resolve(args)
+    })
+  })
+}
+
+function loadWindowConfigs(): Record<string, { partition: string }> {
+  if (existsSync(CONFIG_FILE)) {
+    return JSON.parse(readFileSync(CONFIG_FILE, 'utf-8'))
+  }
+  return {}
+}
+
+function saveWindowConfigs(configs: Record<string, { partition: string }>): void {
+  writeFileSync(CONFIG_FILE, JSON.stringify(configs, null, 2))
+}
+
+function createMenu(mainWindow: BrowserWindow): void {
+  const configs = loadWindowConfigs()
+  const configNames = Object.keys(configs)
+
+  const menuTemplate = [
+    {
+      label: '🪟',
+      tooltip: 'Configure windows',
+      submenu: [
+        ...configNames.map((name) => ({
+          label: name,
+          click: (): ReturnType<typeof createWindow> => createWindow(name)
+        })),
+        {
+          label: '➕🪟🕶️',
+          tooltip: 'Add new private window',
+          click: async (): Promise<void> => {
+            const newConfigName = await launchNewWindowConfig(configs)
+            if (newConfigName) {
+              createWindow(newConfigName)
+            }
+          }
+        },
+        {
+          label: '🔧',
+          tooltip: 'DevTools',
+          click: (): void => {
+            mainWindow.webContents.openDevTools()
+          }
+        },
+      ]
+    }
+  ]
+
+  const menu = Menu.buildFromTemplate(menuTemplate)
+  Menu.setApplicationMenu(menu)
+
+  // Open DevTools when the menu is shown
+  mainWindow.webContents.on('before-input-event', (_event, input) => {
+    if (input.key === 'Alt' && input.code === 'KeyW') {
+      mainWindow.webContents.openDevTools()
+    }
+  })
+}
+
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
 require('./storage.js')

--- a/src/renderer/dialogs/newPrivateWindow.html
+++ b/src/renderer/dialogs/newPrivateWindow.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>New Window Configuration</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      padding: 20px;
+    }
+    label, input {
+      display: block;
+      margin-bottom: 10px;
+    }
+  </style>
+</head>
+<body>
+  <h1>New Window Configuration</h1>
+  <form id="configForm">
+    <label for="configName">Enter a unique name for the new window configuration:</label>
+    <input type="text" id="configName" name="configName" required autofocus>
+    <button type="submit">Submit</button>
+  </form>
+  <script>
+
+    // window.onload = () => {
+    //   const input = document.getElementById('configName')
+    //   if (input) {
+    //     input.focus()
+    //   } else {
+    //     console.error('Input element not found')
+    //   }
+    // }
+
+    const { ipcRenderer } = window.electron
+    document.getElementById('configForm').addEventListener('submit', (event) => {
+      event.preventDefault()
+      const configName = document.getElementById('configName').value
+      ipcRenderer.send('new-config-name', configName)
+    })
+  </script>
+</body>
+</html>

--- a/storage/utils.ts
+++ b/storage/utils.ts
@@ -1,7 +1,7 @@
 import { readJson, read, Stats, ensureFile, readdir } from 'fs-extra'
 import { promisify } from 'util'
 import { stat, open } from 'fs/promises'
-import { posix, resolve } from 'path'
+import { resolve } from 'path'
 
 /**
  * from https://stackoverflow.com/a/45130990/24056785


### PR DESCRIPTION
What issue(s) is this trying to resolve?
* feat(sltt-app): add multiple private window support #35

How does it all work?
* PROBLEM1: compressor server is geared toward single client
* SOLUTION1: make compressor server more cleanly handle multiple browser clients using its services by reading a `client-id` header in `form.on(`fileBegin`)` from the upload file request and using that for storing files related to the request from the client
* PROBLEM2:  testing multi-client file sharing (LAN storage) is burdensome because sltt-app doesn't allow multiple windows with separate caches.
* SOLUTION2: a hidden context menu that can be launched (🪟) by Alt+W and to create a new `Private window` (➕🕶️), select a previously created (and named) window, or bring up devTools (🔧).
  * Private windows use their own `persist:{partition}` so they can have a completely separate cache and can be launched again later.

What particularly has changed?
* change file paths to videos/{client} subdirectory
* fix various logs to include clientId in output
* create temp directory under `/sltt-app/server-29678`
* rename compressor server to `sltt-app server` and bump to version 2.0.0
* configure rolllup to include `src/renderer/dialogs/newPrivateWindow.html` in the out directory (requires yarn build).
* 
Steps for testing
Scenario 1 - dev.sltt-bible.net should work with old compressor
1. Launch the old compressor window
2. Download a video that has a patched segments to test the concatenation of those together.
3. Upload a small video that has `_force_compression_` in its name to force the compressor to run

Scenario 2 - dev.sltt-bible.net should work with sltt-app compressor
1. Close down old compressor server window
2. launch latest draft of sltt-app (standalone), it will launch its own compressor server
3. Repeat steps 2 & 3 from Scenario 1

Scenario 3 - sltt-app should work with its own sltt-app compressor
1. Repeat steps 2 & 3 from Scenario 1 with the sltt-app window. Expect a new directory under `C:\Users\{yourUser}\AppData\Local\Temp\sltt-app\server-29678` and Expect files under video/{clientId} to be deleted after download/upload finishes.

Scenario 4: launch secret context menu in sltt-app
1. press Alt+W and a little 🪟 should pop up. 
2. hover over 🪟 and click on ➕🕶️ to give a name to a new Private window.
3. Give the window a name and click Submit
4. Next time you do Alt+W, that name should show up at the top of the list. 
5. Click it to launch the window you named
6. Enter an Auth0 user name and password, could be completely different than the main window. Expect this to need to download videos again that's already loaded in main window.
7. Click Alt+W and click 🔧 and expect to see Dev Tools opened.

ticket: https://github.com/ubsicap/sltt-app/issues/35
commit-convention: https://www.conventionalcommits.org/en/v1.0.0/
