### PR TITLE
feat(sltt-app): auto-login to samba drive

### DIFF
--- a/storage/connections.ts
+++ b/storage/connections.ts
@@ -94,7 +94,7 @@ export const handleProbeConnections = async (defaultStoragePath: string, { urls 
                         const ipAddress = urlObj.hostname
                         if (ipAddress && ipAddress !== lastSambaIP) {
                             lastSambaIP = ipAddress
-                            connectToSamba(ipAddress)
+                            await connectToSamba(ipAddress)
                         }
                         filePath = fileURLToPath(url)
                     } catch (e) {

--- a/storage/connections.ts
+++ b/storage/connections.ts
@@ -85,14 +85,14 @@ export const handleProbeConnections = async (defaultStoragePath: string, { urls 
     await ensureDir(defaultStoragePath)
     const connections = await Promise.all(
         [pathToFileURL(defaultStoragePath).href, ...(urls || [])]
-            .filter((url) => url && new URL(url).protocol === 'file:')
             .map(
                 async (url) => {
                     let filePath = ''
                     try {
                         const urlObj = new URL(url)
                         const ipAddress = urlObj.hostname
-                        if (ipAddress && ipAddress !== lastSambaIP) {
+                        if (urlObj.protocol === 'file:'
+                            && ipAddress && ipAddress !== lastSambaIP) {
                             lastSambaIP = ipAddress
                             await connectToSamba(ipAddress)
                         }


### PR DESCRIPTION
What issue(s) is this trying to resolve?
* feat(sltt-app): detect when samba drive needs user to login to the router again #44

How does it all work?
* in handleProbeConnections, determine if the url has an ipaddress and if so, issue an OS command (e.g. net use on windows) to authorize the connection once.

Steps for testing
Scenario 1 - newer windows computer
1. connect newer windows (11) computer to network storage samba drive (e.g. via wifi)
2. reboot computer
3. launch latest sltt-app (with these changes). Expect it to detect the local team storage and show an icon that allows an admin to connect and/or turn it on for the project.

Scenario 2 - older windows computer
1. repeat on older Windows 10

Scenario 3: repeat for newer macos computer
Scenario 4: repeat for older macos computer

ticket: https://github.com/ubsicap/sltt-app/issues/44
commit-convention: https://www.conventionalcommits.org/en/v1.0.0/
