### PR TITLE
fix(sltt-app): create sltt-app/lan path for initial storage location #46

### DIFF
--- a/storage/index.ts
+++ b/storage/index.ts
@@ -35,7 +35,7 @@ ipcMain.handle(CONNECTIONS_API_GET_STORAGE_PROJECTS, async (_, args) => {
         && 'clientId' in args && typeof args.clientId === 'string'
         && 'url' in args && typeof args.url === 'string') {
             const { clientId, url }: GetStorageProjectsArgs = args
-        return await handleGetStorageProjects(buildLANStoragePath(DEFAULT_STORAGE_BASE_PATH), { clientId, url })
+        return await handleGetStorageProjects(getLANStoragePath(), { clientId, url })
     } else {
         throw Error(`invalid args for ${CONNECTIONS_API_GET_STORAGE_PROJECTS}. Expected: '{ clientId: string, url: string, project: string }' Got: ${JSON.stringify(args)}`)
     }
@@ -50,7 +50,7 @@ ipcMain.handle(CONNECTIONS_API_ADD_STORAGE_PROJECT, async (_, args) => {
         && 'project' in args && typeof args.project === 'string'
         && 'adminEmail' in args && typeof args.adminEmail === 'string') {
             const { clientId, url, project, adminEmail }: AddStorageProjectArgs = args
-        return await handleAddStorageProject(buildLANStoragePath(DEFAULT_STORAGE_BASE_PATH), { clientId, url, project, adminEmail })
+        return await handleAddStorageProject(getLANStoragePath(), { clientId, url, project, adminEmail })
     } else {
         throw Error(`invalid args for ${CONNECTIONS_API_ADD_STORAGE_PROJECT}. Expected: '{ clientId: string, url: string, project: string, adminEmail: string }' Got: ${JSON.stringify(args)}`)
     }
@@ -65,7 +65,7 @@ ipcMain.handle(CONNECTIONS_API_REMOVE_STORAGE_PROJECT, async (_, args) => {
         && 'project' in args && typeof args.project === 'string'
         && 'adminEmail' in args && typeof args.adminEmail === 'string') {
             const { clientId, url, project, adminEmail }: RemoveStorageProjectArgs = args
-        return await handleRemoveStorageProject(buildLANStoragePath(DEFAULT_STORAGE_BASE_PATH), { clientId, url, project, adminEmail })
+        return await handleRemoveStorageProject(getLANStoragePath(), { clientId, url, project, adminEmail })
     } else {
         throw Error(`invalid args for ${CONNECTIONS_API_REMOVE_STORAGE_PROJECT}. Expected: '{ clientId: string, url: string, project: string, adminEmail: string }' Got: ${JSON.stringify(args)}`)
     }


### PR DESCRIPTION
What issue(s) is this trying to resolve?
* fix(sltt-app): create sltt-app/lan path for initial storage location #46
* fix(sltt-app) get/remove/add storage project(s) whitelist path

How does it all work?
* PROBLEM1 - sltt-app probe api expected that the sltt-app/lan directory exists before return true
* SOLUTION1 - when probing the samba drive for the first time, create the directory if it doesn't already exist before trying to return the access status
* PROBLEM2- sltt-app was using app userData directory for all the calls for get/add/remove storage projects. This would result in other computers never knowing when an admin enables the local team storage since the whitelist is only on their computer.
* SOLUTION2 - use getLANStoragePath() as the basis for the whitelist.sltt-projects file, so it gets shared with others.

Steps for testing
Scenario 1 - connect without existing sltt-app/lan folder
1. setup the samba share name to be `sltt-local-team-storage`
2. delete any `sltt-app/lan` storage directory on its microsd
3. launch sltt-app when connected to the samba's wifi. Expect to see the local team storage icon/button and `sltt-app/lan` directory should be created under `\\192.168.8.1\sltt-local-team-storage`

Scenario2 - share local team storage enabled status (whitelist)
1. enable the local team storage on one computer. Expect to see it enabled on another computer. Also expect the `whitelist.sltt-projects` to exist under `\\192.168.8.1\sltt-local-team-storage`

ticket: https://github.com/ubsicap/sltt/issues/46
commit-convention: https://www.conventionalcommits.org/en/v1.0.0/
