### PR TITLE
chore(sltt-app): add version processing bash script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Since I (EricP) could not bring myself to install (3.5Gb) WindowsSDK just to hav
 https://knowledge.digicert.com/tutorials/configure-keylocker-for-jsign-using-the-pkcs11-library
 *NOTE*: this requires JavaRE to be installed to run the `java` command
 
+See also github workflow https://github.com/ubsicap/sltt/blob/dev/.github/workflows/publish-sltt-app.yml
+
 After everything is setup, the following command can be used to sign the installer:
 
 ```bash

--- a/jq.bash
+++ b/jq.bash
@@ -26,7 +26,9 @@ echo NEW_VALUE_2____: $NEW_VALUE_2
 # Update package.json with the new value
 # jq --arg new_value "$NEW_VALUE" '.scripts["find:version:source"] = $new_value' "$PACKAGE_JSON_PATH" > "$TEMP_JSON_PATH" && mv "$TEMP_JSON_PATH" "$PACKAGE_JSON_PATH"
 # jq --arg new_value "$NEW_VALUE_1" '.scripts["find:version:source"] = "new_value_for_source" | .scripts["find:version:target"] = "new_value_for_target"' # package.json > package.tmp.json && mv package.tmp.json package.json
-jq --arg new_value_1 "$NEW_VALUE_1" --arg new_value_2 "$NEW_VALUE_2" '.scripts["find:version:source"] = $new_value_1 | .scripts["find:version:target"] = $new_value_2' package.json # > package.tmp.json && mv package.tmp.json package.json
+jq --arg new_value_1 "$NEW_VALUE_1" --arg new_value_2 "$NEW_VALUE_2" \
+    '.scripts["find:version:source"] = $new_value_1 | .scripts["find:version:target"] = $new_value_2' \
+    package.json # > package.tmp.json && mv package.tmp.json package.json
 # jq '.scripts["find:version:source"] = "findstr /S /M /C:\"version = \\\"new_version_source\\\"\" %SLTT_CLIENT_DIR%\\build\\assets\\index-*.js" | .scripts["find:version:target"] = "findstr /S /M /C:\"version = \\\"new_version_target\\\"\" out\\client\\assets\\index-*.js"' package.json > package.tmp.json && mv package.tmp.json package.json
 
 

--- a/jq.bash
+++ b/jq.bash
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Check if jq is installed
+if ! command -v jq &> /dev/null
+then
+    echo "jq could not be found. Please install jq to use this script."
+    exit 1
+fi
+
+# Define old and new versions
+NEW_VERSION="3.0.0"
+
+# Extract the current value of .scripts["find:version:source"]
+CURRENT_VALUE_1=$(jq -r ".scripts[\"find:version:source\"]" package.json)
+CURRENT_VALUE_2=$(jq -r ".scripts[\"find:version:target\"]" package.json)
+
+# Perform the substitution using sed
+NEW_VALUE_1=$(echo "$CURRENT_VALUE_1" | sed -E "s/version = \\\\\\\"[^\"]+\"/version = \\\\\\\"$NEW_VERSION\\\\\\\"/")
+NEW_VALUE_2=$(echo "$CURRENT_VALUE_2" | sed -E "s/version = \\\\\\\"[^\"]+\"/version = \\\\\\\"$NEW_VERSION\\\\\\\"/")
+
+echo CURRENT_VALUE_1: $CURRENT_VALUE_1
+echo NEW_VALUE_1____: $NEW_VALUE_1
+echo CURRENT_VALUE_2: $CURRENT_VALUE_2
+echo NEW_VALUE_2____: $NEW_VALUE_2
+
+# Update package.json with the new value
+# jq --arg new_value "$NEW_VALUE" '.scripts["find:version:source"] = $new_value' "$PACKAGE_JSON_PATH" > "$TEMP_JSON_PATH" && mv "$TEMP_JSON_PATH" "$PACKAGE_JSON_PATH"
+# jq --arg new_value "$NEW_VALUE_1" '.scripts["find:version:source"] = "new_value_for_source" | .scripts["find:version:target"] = "new_value_for_target"' # package.json > package.tmp.json && mv package.tmp.json package.json
+jq --arg new_value_1 "$NEW_VALUE_1" --arg new_value_2 "$NEW_VALUE_2" '.scripts["find:version:source"] = $new_value_1 | .scripts["find:version:target"] = $new_value_2' package.json # > package.tmp.json && mv package.tmp.json package.json
+# jq '.scripts["find:version:source"] = "findstr /S /M /C:\"version = \\\"new_version_source\\\"\" %SLTT_CLIENT_DIR%\\build\\assets\\index-*.js" | .scripts["find:version:target"] = "findstr /S /M /C:\"version = \\\"new_version_target\\\"\" out\\client\\assets\\index-*.js"' package.json > package.tmp.json && mv package.tmp.json package.json
+
+
+# Print the updated package.json
+# cat "$PACKAGE_JSON_PATH"


### PR DESCRIPTION
What issue(s) is this trying to resolve?
* chore(sltt-app): add version processing bash script and update README

How does it all work?
* add a bash script to test version extraction/substitution for sltt-app releases

Steps for testing (dev)
1.  in bash shell, run `bash jq.bash`. Expect to see package.json dump with version 3.0.0 in `find:version:source` and `find:version:target` scripts

![image](https://github.com/user-attachments/assets/ddf2a284-9dee-4465-9a85-088d3b4ef9b3)


ticket: https://github.com/ubsicap/sltt-app/issues/XXX
commit-convention: https://www.conventionalcommits.org/en/v1.0.0/
