### PR TITLE
fix(sltt-app): detachable window should not show blank window

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,7 +52,13 @@ function createWindow(partition?: string): BrowserWindow {
     // This is the name we chose for our window. You can have multiple names for
     // multiple windows and each have their options
     if (url.startsWith('about:blank')) {
-      return { action: 'allow', overrideBrowserWindowOptions: { autoHideMenuBar: true } }
+      return {
+        action: 'allow',
+        overrideBrowserWindowOptions: {
+          autoHideMenuBar: true,
+          alwaysOnTop: true,
+        }
+      }
     }
     shell.openExternal(url)
     return { action: 'deny' }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -49,8 +49,6 @@ function createWindow(partition?: string): BrowserWindow {
 
   win.webContents.setWindowOpenHandler(({ url, frameName, disposition, features, referrer, postBody }) => {
     console.log('window open handler', { url, frameName, disposition, features, referrer, postBody })
-    // This is the name we chose for our window. You can have multiple names for
-    // multiple windows and each have their options
     if (url.startsWith('about:blank')) {
       return {
         action: 'allow',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -47,8 +47,14 @@ function createWindow(partition?: string): BrowserWindow {
     windowsCreated.splice(windowsCreated.indexOf(win), 1)
   })
 
-  win.webContents.setWindowOpenHandler((details) => {
-    shell.openExternal(details.url)
+  win.webContents.setWindowOpenHandler(({ url, frameName, disposition, features, referrer, postBody }) => {
+    console.log('window open handler', { url, frameName, disposition, features, referrer, postBody })
+    // This is the name we chose for our window. You can have multiple names for
+    // multiple windows and each have their options
+    if (url.startsWith('about:blank')) {
+      return { action: 'allow' }
+    }
+    shell.openExternal(url)
     return { action: 'deny' }
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,7 +52,7 @@ function createWindow(partition?: string): BrowserWindow {
     // This is the name we chose for our window. You can have multiple names for
     // multiple windows and each have their options
     if (url.startsWith('about:blank')) {
-      return { action: 'allow' }
+      return { action: 'allow', overrideBrowserWindowOptions: { autoHideMenuBar: true } }
     }
     shell.openExternal(url)
     return { action: 'deny' }


### PR DESCRIPTION
What issue(s) is this trying to resolve?
* fix(sltt-app): detachable window should not show blank window #53

How does it all work?
* use contents.setWindowOpenHandler api to filter on `about:blank` and open a window on top without a menu bar. Otherwise open url in browser

Steps for testing
1. See test steps for https://github.com/ubsicap/sltt/pull/1113

ticket: https://github.com/ubsicap/sltt-app/issues/53
commit-convention: https://www.conventionalcommits.org/en/v1.0.0/
