### PR TITLE
feat(sltt-app): register and handle custom protocol sltt-app

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -12,6 +12,11 @@ files:
 asarUnpack:
   - resources/**
 afterSign: build/notarize.js
+protocols:
+  name: sltt-app protocol
+  schemes:
+    - sltt-app
+  role: Editor
 win:
   executableName: sltt-app
 nsis:


### PR DESCRIPTION
What issue(s) is this trying to resolve?
* feat(sltt-app): register sltt-app custom protocol #57

How does it all work?
* register `sltt-app` as default protocol
* determine if process.args starts with sltt-app OR if on `open-url` or `second-instance` whether arg starts with sltt-app
  *  handle by extracting the search params and passing that to loadFile() options

What particularly has changed?
* electron-builder.yml adds protocols section

Steps for testing
1. 


ticket: https://github.com/ubsicap/sltt-app/issues/57
commit-convention: https://www.conventionalcommits.org/en/v1.0.0/
